### PR TITLE
QP-2109 Make fulfillment-location-client open-source

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        [
+          "istanbul",
+          {
+            "exclude": [
+              "**/node_modules/**",
+              "**/tests/**",
+              "**/coverage/**",
+              "Gruntfile.js"
+            ]
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage/**
+Gruntfile.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,35 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true
+        }
+    },
+    "env": {
+        "mocha": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended"
+    ],
+    "rules": {
+        // "off", "warn", "error" : values to en/disable rules
+        "quotes": ["off", "single"],
+        "indent": ["warn", 4, { "SwitchCase": 1 }],
+        "no-unused-vars": ["error", { "vars": "all", "args": "all", "argsIgnorePattern": "^(next|_+)" }],
+        "no-console": "error",
+        "semi": ["error", "always"],
+        "no-extra-semi": "warn",
+        "curly": ["error", "all"],
+        "multiline-ternary": ["error", "always"],
+        "operator-linebreak": ["error", "before"],
+        "space-infix-ops": ["error", {"int32Hint": true}],
+        "newline-per-chained-call": ["error"],
+        "keyword-spacing": ["error", { "overrides": {} }],
+        "object-curly-spacing": ["warn", "always"],
+        "array-bracket-spacing": ["off", "always"],
+        "no-undef": ["error"]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea/
+coverage/
+.vscode/
+node_modules/
+typings/
+.nyc_output
+jsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-.idea/
-coverage/
-.vscode/
 node_modules/
+*.zip
+coverage/
+npm-debug.log
 typings/
-.nyc_output
+.vscode/
 jsconfig.json
+.idea/
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,24 @@
+{
+  "include": [
+    "**/*.js",
+    "**/*.jsx"
+  ],
+  "exclude": [
+    "**/coverage/**",
+    "dist/**"
+  ],
+  "require": [
+    "babel-register"
+  ],
+  "reporter": [
+    "html",
+    "text-summary"
+  ],
+  "extension": [
+    ".js"
+  ],
+  "all": true,
+  "cache": true,
+  "sourceMap": false,
+  "instrument": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+- '6'
+install:
+- npm install
+script:
+- npm run code-check
+- npm run cover
+- grunt build
+deploy:
+  provider: npm
+  skip_cleanup: true
+  email: indirapranabudi@gmail.com
+  api_key:
+    secure: ee7KdyuJ4e7DXF+nLVBCcwrPqzUT0Dt/b6hlvPbn0xF3acPGGHaZGcp1vwKAv1+lsiF/KpPPRiYoAIhg0i7YoO1Oj8upcWoFi5PLNX4E9sMKYaQjKtHXQjNnQetn8EGCozM43h660xmi7y7RZtLFtLM2nAyehS6OdHlpdHnLZrvDqeyz16dwqWIrwkA6eUOreysUEYi7kYZslLrZjZZz0mSJ1pLs0+vir4bCDWTlsMiQqT5VNJFiLbXwp2BJmT3KsVjcb6njyHnIMrWXLB96Px8nV6BC+7eyBFFrZUuAcf0zNJkOgs6sL8Uht4cMhPGLX/fTZqP3S4NUkRUlJk0Ix9sLDLnuh2wUJg4MnFvgjdcFNBsKhIbGmMGZC9eDvY/WvSL99EiTyugv0cgKHOWZyv1Q4HIS+4neeioLzNe6OMCU40t+TZFGwRNsGrDaS7hkvDCdUY1Ezg6QEAY4A8xBHpgkufJBaxcjWhjRnriuhfXdzSVrKrJ+3/OlYZrYiKQZcYJfvcdMUnjxZWgiiie6FXgqzIEUHR+sSNBBbhdurtt75RqTErQUN07QNA+NEga5HK3XvJAmAZ3WjCSWaSJ6z+w7u7yUHMb2Nn8sVyPqkiKpUE8TaR65/7onWAeAPggnbg91xp0g5NdSFec3C7Gabbm7/cpJM0BuAVmk3VFlQlQ=
+  on:
+    branch: master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const npm = /^win/.test(process.platform)
+    ? 'npm.cmd'
+    : 'npm';
+
+module.exports = function (grunt) {
+
+    const version = "0.1." + process.env.TRAVIS_BUILD_NUMBER;
+
+    require('load-grunt-tasks')(grunt);
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+
+    grunt.initConfig({
+        clean: {
+            dist: ['dist/']
+        },
+        copy: {
+            main: {
+                files: [{
+                    expand: true,
+                    src: ['package.json', '*.md'],
+                    dest: 'dist/',
+                    filter: 'isFile'
+                }]
+            }
+        },
+        exec: {
+            setVersion: {
+                cwd: 'dist',
+                command: `${npm} version ${version} --no-git-tag-version --allow-same-version`
+            }
+        },
+        babel: {
+            options: {
+                sourceMap: true,
+            },
+            dist: {
+                files: {
+                    'dist/index.js': 'src/index.js',
+                    'dist/fulfillmentLocation.js': 'src/fulfillmentLocation.js'
+                }
+            }
+        }
+    });
+
+    grunt.registerTask('build', ['clean:dist', 'babel', 'copy', 'exec:setVersion']);
+};

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ client.getLocations(req.headers.authorization)
     });
 ```
 
+You may also run `node sampleUsage.js` as an example.
+
 ### Prerequisites
 * [Node.js](https://nodejs.org/en/)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Cimpress Fulfillment Location client
+
+This repository is maintained by the [Logistics Quoting & Planning Squad](mailto:LogisticsQuotingandPlanning@cimpress.com).
+It contains a simple client to help getting information from the Fulfillment Location service owned by the [TRDLNK squad](mailto:TrdelnikSquad@cimpress.com).
+
+### Usage
+In order to use the client, install the package by running:
+```
+npm install cimpress-fulfillment-location --save
+```
+
+Once the package is avialable, you can retrieve a specific fulfillment location as such:
+```
+const fulfillmentLocationId = 'abcd1234';
+let client = new FulfillmentLocationClient({
+    log: defaultLogger,
+    cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+});
+
+client.getLocation(fulfillmentLocationId, req.headers.authorization)
+    .then(fulfillmentLocation => {
+        // do stuff
+    });
+```
+
+Otherwise, you can retrieve a list of all the fulfillment locations you have access to like this:
+```
+let client = new FulfillmentLocationClient({
+    log: defaultLogger
+});
+
+client.getLocations(req.headers.authorization)
+    .then(fulfillmentLocations => {
+        // do stuff
+    });
+```
+
+### Prerequisites
+* [Node.js](https://nodejs.org/en/)
+
+### Other QP Resources
+* [qp-node-components](https://mcpstash.cimpress.net/projects/QP/repos/qp-node-components/browse)
+* [qp-validators](https://mcpstash.cimpress.net/projects/QP/repos/qp-validators/browse)
+* [simple-coam-auth](https://mcpstash.cimpress.net/projects/QP/repos/simple-coam-auth/browse)
+* [qp-quoter-client](https://mcpstash.cimpress.net/projects/QP/repos/qp-quoter-client/browse)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fulfillment-location-client",
-  "version": "0.0.1",
+  "version": "0.1",
   "author": "LogisticsQuotingandPlanning@cimpress.com",
   "description": "A simple client for TRDLNK's Fulfillment Location service",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "fulfillment-location-client",
+  "version": "0.0.1",
+  "author": "LogisticsQuotingandPlanning@cimpress.com",
+  "description": "A simple client for TRDLNK's Fulfillment Location service",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "6.11.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://cimpress.githost.io/qp/fulfillment-location-client.git"
+  },
+  "dependencies": {
+    "axios": "^0.16.2",
+    "node-cache": "^4.1.1"
+  },
+  "scripts": {
+    "test": "mocha --recursive tests",
+    "check-cover": "nyc check-coverage",
+    "cover": "cross-env BABEL_ENV=test nyc ./node_modules/mocha/bin/_mocha --recursive tests && npm run check-cover -- --lines 88",
+    "code-check": "eslint --ext .js --ext .jsx src",
+    "eslint-report": "eslint --ext .js --ext .jsx . -f node_modules/eslint-html-reporter/reporter.js -o eslint.report.html",
+    "eslint": "eslint",
+    "build": "npm run code-check && npm run cover"
+  },
+  "devDependencies": {
+    "babel-plugin-istanbul": "^4.1.4",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-register": "^6.24.1",
+    "chai": "^4.1.2",
+    "cross-env": "^5.0.1",
+    "eslint": "^4.2.0",
+    "eslint-html-reporter": "^0.5.2",
+    "grunt": "^1.0.1",
+    "grunt-babel": "^6.0.0",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-exec": "^2.0.0",
+    "load-grunt-tasks": "^3.5.2",
+    "mocha": "^3.4.2",
+    "nock": "^9.0.22",
+    "nyc": "^11.0.3",
+    "sinon": "^4.0.1"
+  }
+}

--- a/sampleUsage.js
+++ b/sampleUsage.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const FulfillmentLocationClient = require('./src/fulfillmentLocation');
+const fulfillmentLocationService = new FulfillmentLocationClient({
+    log: {
+        info: (message) => {
+            console.log(message);
+        }
+    }
+});
+
+// Fill this in with a v2 token
+const authorization = 'Bearer [token]';
+
+const locationId = 'a7uqagcx0nz';
+console.log('Fetching location from FL service...');
+fulfillmentLocationService
+    .getLocation(locationId, authorization)
+    .then(location => {
+        console.log('Location Info');
+        console.log(location);
+    })
+    .catch(error => {
+        console.error('Error from FL client');
+        console.error(error);
+    });

--- a/src/fulfillmentLocation.js
+++ b/src/fulfillmentLocation.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const DEFAULT_URL = "https://fulfillmentlocation.trdlnk.cimpress.io";
+
+const nodeCache = require('node-cache');
+let flCache;
+let axios = require('axios');
+
+// --- Predefined errors ---
+
+function UnauthorizedError(message, extra) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message || 'Unauthorized';
+    this.status = 401;
+    this.additionalData = extra;
+}
+
+function ForbiddenError(message, extra) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message || 'Forbidden';
+    this.status = 403;
+    this.additionalData = extra;
+}
+
+function NotFoundError(message, extra) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message || 'Not found';
+    this.status = 404;
+    this.additionalData = extra;
+}
+
+// --- END ---
+
+const handleAuthorization = (authorization, reject) => {
+    if ( !authorization ) {
+        return reject(new Error('Missing Authorization parameter'));
+    }
+
+    if ( authorization.indexOf('Bearer ') !== 0 ) {
+        return reject(new Error(`Invalid format for Authorization parameter: "${authorization}". Authorization parameter should be in the following`
+            + ` format: "Bearer [token]"`));
+    }
+};
+
+const handleError = (err, reject) => {
+    if ( err.status === 401 || (err.response && err.response.status === 401) ) {
+        return reject(new UnauthorizedError(err.statusText || err.message, err.data || err.response.data));
+    }
+    if ( err.status === 403 || (err.response && err.response.status === 403) ) {
+        return reject(new ForbiddenError(err.statusText || err.message, err.data || err.response.data));
+    }
+    if ( err.status === 404 || (err.response && err.response.status === 404) ) {
+        return reject(new NotFoundError(err.statusText || err.message, err.data || err.response.data));
+    }
+    return reject(err);
+};
+
+class FulfillmentLocationClient {
+
+    constructor(c) {
+        let config = c || {};
+        this.url = config.url || DEFAULT_URL;
+        this.log = config.log;
+        this.useCaching = !!config.cacheConfig;
+        if ( config.cacheConfig ) {
+            flCache = new nodeCache(config.cacheConfig);
+        }
+        this.timeout = config.timeout || 2000;
+    }
+
+    getLocation(locationId, authorization) {
+
+        return new Promise((resolve, reject) => {
+            handleAuthorization(authorization, reject);
+            
+            const instance = axios.create({
+                baseURL: this.url,
+                timeout: this.timeout
+            });
+
+            instance.defaults.headers.common['Authorization'] = authorization;
+
+            if ( !this.useCaching ) {
+                return this._getFulfillmentLocationFromService(instance, locationId)
+                    .then(location => {
+                        return resolve(location);
+                    })
+                    .catch(err => {
+                        return reject(err);
+                    });
+            }
+
+            const cacheKey = 'fulfillmentLocation_' + locationId + '_' + authorization;
+            flCache.get(cacheKey, (err, fulfillmentLocation) => {
+
+                if ( err ) {
+                    this.log.error(`Failed to read from node-cache (key=${cacheKey})`, err);
+                }
+
+                if ( err || (fulfillmentLocation == undefined) ) {
+
+                    return this._getFulfillmentLocationFromService(instance, locationId)
+                        .then(location => {
+                            flCache.set(cacheKey, location);
+                            return resolve(location);
+                        })
+                        .catch(err => {
+                            return reject(err);
+                        });
+
+                } else {
+                    return resolve(fulfillmentLocation);
+                }
+
+            });
+        });
+    }
+
+    getLocations(authorization) {
+
+        return new Promise((resolve, reject) => {
+            handleAuthorization(authorization, reject);
+
+            const instance = axios.create({
+                baseURL: this.url,
+                timeout: this.timeout
+            });
+    
+            instance.defaults.headers.common['Authorization'] = authorization;
+    
+            if ( !this.useCaching ) {
+                return this._getFulfillmentLocationsFromService(instance)
+                    .then(locations => {
+                        return resolve(locations);
+                    })
+                    .catch(err => {
+                        return reject(err);
+                    });
+            }
+
+            const cacheKey = 'fulfillmentLocations_' + authorization;
+            flCache.get(cacheKey, (err, fulfillmentLocations) => {
+
+                if ( err ) {
+                    this.log.error(`Failed to read from node-cache (key=${cacheKey})!?`, err);
+                }
+
+                if ( err || (fulfillmentLocations == undefined) ) {
+
+                    return this._getFulfillmentLocationsFromService(instance)
+                        .then(locations => {
+                            flCache.set(cacheKey, locations);
+                            return resolve(locations);
+                        })
+                        .catch(err => {
+                            return reject(err);
+                        });
+
+                } else {
+                    return resolve(fulfillmentLocations);
+                }
+
+            });
+        });
+    }
+
+    _getFulfillmentLocationFromService(instance, fulfillmentLocationId) {
+        return new Promise((resolve, reject) => {
+            const endpoint = this.url + "/v1/fulfillmentlocations/" + fulfillmentLocationId;
+            const requestConfig = {
+                method: 'GET',
+                url: endpoint,
+                qs: {
+                    showArchived: false
+                },
+                timeout: this.timeout
+            };
+
+            if ( this.log && this.log.info ) {
+                this.log.info("->" + endpoint, requestConfig);
+            }
+
+            instance
+                .request(requestConfig)
+                .then(res => {
+                    
+                    if ( this.log && this.log.info ) {
+                        this.log.info("<-" + endpoint, res.data);
+                    }
+
+                    return resolve(res.data || []);
+                })
+                .catch(err => {
+                    if ( this.log && this.log.error ) {
+                        this.log.error("<-" + endpoint, err);
+                    }
+
+                    return handleError(err, reject);
+                });
+        });
+    }
+
+    _getFulfillmentLocationsFromService(instance) {
+        return new Promise((resolve, reject) => {
+            const endpoint = this.url + "/v1/fulfillmentlocations";
+            const requestConfig = {
+                method: 'GET',
+                url: endpoint,
+                qs: {
+                    showArchived: false
+                },
+                timeout: this.timeout
+            };
+
+            if ( this.log && this.log.info ) {
+                this.log.info("->" + endpoint, requestConfig);
+            }
+
+            instance
+                .request(requestConfig)
+                .then((res) => {
+
+                    if ( this.log && this.log.info ) {
+                        this.log.info("<-" + endpoint, res.data);
+                    }
+
+                    return resolve(res.data || []);
+                })
+                .catch((err) => {
+
+                    if ( this.log && this.log.error ) {
+                        this.log.error("<-" + endpoint, err);
+                    }
+
+                    return handleError(err, reject);
+                });
+        });
+    }
+}
+
+module.exports = FulfillmentLocationClient;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.FulfillmentLocationClient = require('./fulfillmentLocation');

--- a/tests/getFulfillmentLocationTests.js
+++ b/tests/getFulfillmentLocationTests.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const expect = require('chai').expect;
+const nock = require('nock');
+const sinon = require('sinon');
+
+const FulfillmentLocationClient = require('../src/fulfillmentLocation');
+
+// ----- Helpers -----
+
+const defaultLogger = () => ({
+    info: sinon.stub(),
+    error: sinon.stub()
+});
+
+const sampleLocation = () => (
+    {
+        timeZone: "Europe/London",
+        internalFulfillerId: 70,
+        internalFulfillmentLocationId: 110,
+        fulfillerId: "a2wgr294u",
+        fulfillmentLocationId: "b7uqagcx0nw"
+    }
+);
+
+// ----- END -----
+
+describe('getLocation :: without cache ::', function () {
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it('FL service returns 200 and the location requested (using alphanum id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service returns 404 for invalid alphanum id', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/a7uqagcx0nz")
+            .reply(404, "Location 'a7uqagcx0nz' not found");
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("a7uqagcx0nz", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(404);
+                expect(error.additionalData).to.equal(`Location 'a7uqagcx0nz' not found`);
+            });
+    });
+
+    it('FL service returns 200 and the location requested (using internal id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/189")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("189", 'Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service returns 404 for invalid internal id', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/180")
+            .reply(404, "Location '180' not found");
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("180", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(404);
+                expect(error.additionalData).to.equal(`Location '180' not found`);
+            });
+    });
+
+    it('FL service returns 401 for unauthorized user', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/180")
+            .reply(401);
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("180", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(401);
+            });
+    });
+
+    it('FL service returns 403 for forbidden', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/180")
+            .reply(403);
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("180", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(403);
+            });
+    });
+
+    it('Authorization parameter is not passed :: returns an error', function () {
+        nock.cleanAll();
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("180")
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.message).to.equal('Missing Authorization parameter');
+            });
+    });
+
+    it('Authorization parameter is of an invalid format :: returns an error', function () {
+        nock.cleanAll();
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("180", "invalid-format")
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.message).to.equal('Invalid format for Authorization parameter: "invalid-format". Authorization parameter should be in the following format: "Bearer [token]"');
+            });
+    });
+});
+
+describe('getLocation :: with cache ::', function () {
+    
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it('FL service returns 200 and the location requested (using alphanum id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service returns 404 for invalid alphanum id', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/a7uqagcx0nz")
+            .reply(404, "Location 'a7uqagcx0nz' not found");
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("a7uqagcx0nz", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(404);
+                expect(error.additionalData).to.equal(`Location 'a7uqagcx0nz' not found`);
+            });
+    });
+
+    it('FL service returns 200 and the location requested (using internal id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/189")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("189", 'Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service returns 404 for invalid internal id', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/180")
+            .reply(404, "Location '180' not found");
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("180", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(404);
+                expect(error.additionalData).to.equal(`Location '180' not found`);
+            });
+    });
+
+    it('FL returns 500 :: location is in cache and uses the value in the cache', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client
+            .getLocation("bqcjg7qbvep", 'Bearer X')
+            .then(_data => {
+                // FL service is now returning a 404; client should use data in cache
+                nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+                    .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+                    .reply(500, "Unable to load information for 'bqcjg7qbvep'");
+
+                client
+                    .getLocation("bqcjg7qbvep", 'Bearer X')
+                    .then(data => {
+                        expect(data).to.deep.equal(sampleLocation());
+                    })
+                    .catch(error => {
+                        expect(error).to.not.exist;
+                    });
+            });
+    });
+
+    it('FL returns 500 :: returns an error', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(500, "Unable to load information for 'bqcjg7qbvep'");
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.response.status).to.equal(500);
+                expect(error.response.data).to.equal("Unable to load information for 'bqcjg7qbvep'");
+            });
+    });
+});

--- a/tests/getFulfillmentLocationsTests.js
+++ b/tests/getFulfillmentLocationsTests.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const expect = require('chai').expect;
+const nock = require('nock');
+const sinon = require('sinon');
+
+const FulfillmentLocationClient = require('../src/fulfillmentLocation');
+
+// ----- Helpers -----
+
+const defaultLogger = () => ({
+    info: sinon.stub(),
+    error: sinon.stub()
+});
+
+const sampleLocations = () => (
+    [
+        {
+            timeZone: "Europe/London",
+            internalFulfillerId: 70,
+            internalFulfillmentLocationId: 110,
+            fulfillerId: "a2wgr294u",
+            fulfillmentLocationId: "b7uqagcx0nw"
+        },
+        {
+            timeZone: "Europe/Paris",
+            internalFulfillerId: 70,
+            internalFulfillmentLocationId: 189,
+            fulfillerId: "a2wgr294u",
+            fulfillmentLocationId: "bqcjg7qbvep"
+        }
+    ]
+);
+
+// ----- END -----
+
+describe('getLocations :: without cache ::', function () {
+    
+    it('FL returns 200 :: returns list of fulfillment locations correctly', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocations());
+            });
+    });
+
+    it('FL returns 500 :: returns an error', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .times(1)
+            .reply(500, 'Unable to load locations');
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.response.status).to.equal(500);
+                expect(error.response.data).to.equal('Unable to load locations');
+            });
+    });
+
+    it('FL service returns 404 for invalid alphanum id', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .reply(404);
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(404);
+            });
+    });
+
+    it('FL service returns 401 for unauthorized user', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .reply(401);
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(401);
+            });
+    });
+
+    it('FL service returns 403 for forbidden', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .reply(403);
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.status).to.equal(403);
+            });
+    });
+
+    it('Authorization parameter is not passed :: returns an error', function () {
+        nock.cleanAll();
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations()
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.message).to.equal('Missing Authorization parameter');
+            });
+    });
+
+    it('Authorization parameter is of an invalid format :: returns an error', function () {
+        nock.cleanAll();
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations('invalid-format')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.message).to.equal('Invalid format for Authorization parameter: "invalid-format". Authorization parameter should be in the following format: "Bearer [token]"');
+            });
+    });
+});
+
+describe('getLocations :: with cache ::', function () {
+    
+    it('FL returns 200 :: returns list of fulfillment locations correctly', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocations());
+            });
+    });
+
+    it('locations are in the cache and uses the value in the cache', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocations('Bearer X')
+            .then(_data => {
+                nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+                    .get("/v1/fulfillmentlocations")
+                    .times(1)
+                    .reply(500, 'Unable to load locations');
+
+                client.getLocations('Bearer X')
+                    .then(data => {
+                        expect(data).to.deep.equal(sampleLocations());
+                    })
+                    .catch(error => {
+                        expect(error).to.not.exist;
+                    });
+            });
+    });
+
+    it('FL returns 500 :: returns an error', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io')
+            .get("/v1/fulfillmentlocations")
+            .times(1)
+            .reply(500, 'Unable to load locations');
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocations('Bearer X')
+            .then(data => {
+                expect(data).to.not.exist;
+            })
+            .catch(error => {
+                expect(error.response.status).to.equal(500);
+                expect(error.response.data).to.equal('Unable to load locations');
+            });
+    });
+});

--- a/tests/indexTests.js
+++ b/tests/indexTests.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+describe('Index', () => {
+
+    it('Exports correctly', () => {
+
+        let exported = require('../src/index');
+        expect(exported).to.deep.equal({
+            FulfillmentLocationClient: require('../src/fulfillmentLocation')
+        });
+
+    });
+
+});


### PR DESCRIPTION
I've removed the GitLab CI stuff and added a `travis.yml` file, following what's in [`cimpress-fulfiller-identity`](https://github.com/Cimpress/cimpress-fulfiller-identity/blob/master/.travis.yml). I wasn't sure about the NPM `api_key` and `email`, but I added my NPM account there for now. I've also updated the Gruntfile to remove all the AWS S3 related stuff.

I tried to just push what we had in GitLab here so as to retain the Git commit history, but it was saying something like the two repos have different histories and can't merge, so I just copied all the files here. Sorry, my Git knowledge fails me :disappointed: 