### PR TITLE
Add skip Cache and reformat parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ typings/
 jsconfig.json
 .idea/
 .nyc_output/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.2] - 2018-10-03
 ### Added
 - Enable showArchived flag for listing fulfillment locations.
+
+## [1.0] - 2018-11-29
+### Changed
+- Aditional properties of getLocations and getLocation moved to a single object paramenter `options`. 
+
+### Added
+- Added new skipCache option that disables all the caches.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ let client = new FulfillmentLocationClient({
     timeout: 2000
 });
 
-client.getLocation(fulfillmentLocationId, req.headers.authorization)
+client.getLocation(fulfillmentLocationId{
+    authorization: "Your access token",
+    skipCache: false, // Skips the cache so the results will be fresh, if not set is false by default
+})
     .then(fulfillmentLocation => {
         // do stuff
     });
@@ -27,13 +30,11 @@ let client = new FulfillmentLocationClient({
     log: defaultLogger
 });
 
-client.getLocations(req.headers.authorization)
-    .then(fulfillmentLocations => {
-        // do stuff
-    });
-
-// To include also archived fulfillment locations
-client.getLocations(req.headers.authorization, true)
+client.getLocations({
+    authorization: "Your access token",
+    showArchived: false, // By default is false, shows archived fulfillment locations
+    skipCache: false // Skips the cache so the results will be fresh, if not set is false by default
+})
     .then(fulfillmentLocations => {
         // do stuff
     });

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ let client = new FulfillmentLocationClient({
     timeout: 2000
 });
 
-client.getLocation(fulfillmentLocationId{
+client.getLocation(fulfillmentLocationId, {
     authorization: "Your access token",
     skipCache: false, // Skips the cache so the results will be fresh, if not set is false by default
 })

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ let client = new FulfillmentLocationClient({
 });
 
 client.getLocation(fulfillmentLocationId, {
-    authorization: "Your access token",
+    accessToken: "Your access token",
     skipCache: false, // Skips the cache so the results will be fresh, if not set is false by default
 })
     .then(fulfillmentLocation => {
@@ -31,7 +31,7 @@ let client = new FulfillmentLocationClient({
 });
 
 client.getLocations({
-    authorization: "Your access token",
+    accessToken: "Your access token",
     showArchived: false, // By default is false, shows archived fulfillment locations
     skipCache: false // Skips the cache so the results will be fresh, if not set is false by default
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfillment-location",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -216,11 +216,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "^1.3.0",
+        "follow-redirects": "^1.2.3",
         "is-buffer": "^1.1.5"
       }
     },
@@ -1894,9 +1894,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
-      "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       }
@@ -3670,9 +3670,9 @@
       }
     },
     "nock": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.0.tgz",
-      "integrity": "sha512-hE0O9Uhrg7uOpAqnA6ZfnvCS/TZy0HJgMslJ829E7ZuRytcS86/LllupHDD6Tl8fFKQ24kWe1ikX3MCrKkwaaQ==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
+      "integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
       "dev": true,
       "requires": {
         "chai": "^4.1.2",
@@ -6802,9 +6802,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
       "dev": true
     },
     "randomatic": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-fulfillment-location",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "LogisticsQuotingandPlanning@cimpress.com",
   "description": "A simple client for the Cimpress Fulfillment Location service",
   "license": "Apache-2.0",

--- a/src/fulfillmentLocation.js
+++ b/src/fulfillmentLocation.js
@@ -53,7 +53,7 @@ const handleError = (err, reject) => {
         return reject(new ForbiddenError(err.statusText || err.message, err.data || err.response.data));
     }
     if ( err.status === 404 || (err.response && err.response.status === 404) ) {
-        return reject(new NotFoundError(err.statusText || err.message, err.data || err.response ? err.response.data : err));
+        return reject(new NotFoundError(err.statusText || err.message, err.data || err.response.data));
     }
     return reject(err);
 };
@@ -177,7 +177,7 @@ class FulfillmentLocationClient {
                 headers: {}
             };
             
-            if(options.skipCache){
+            if (options.skipCache){
                 requestConfig.headers['Cache-Control'] = 'no-cache';
                 requestConfig.headers['X-Cache-Id'] = Math.random();
             }
@@ -219,7 +219,7 @@ class FulfillmentLocationClient {
                 timeout: this.timeout
             };
 
-            if(options.skipCache){
+            if (options.skipCache){
                 requestConfig.headers['Cache-Control'] = 'no-cache';
                 requestConfig.headers['X-Cache-Id'] = Math.random();
             }
@@ -229,7 +229,7 @@ class FulfillmentLocationClient {
             }
             
             instance
-            .request(requestConfig)
+                .request(requestConfig)
                 .then((res) => {
 
                     if ( this.log && this.log.info ) {

--- a/src/fulfillmentLocation.js
+++ b/src/fulfillmentLocation.js
@@ -75,13 +75,13 @@ class FulfillmentLocationClient {
 
         return new Promise((resolve, reject) => {
             const opts = options || {};
-            handleAuthorization(opts.authorization, reject);
+            handleAuthorization(opts.accessToken, reject);
             const instance = axios.create({
                 baseURL: this.url,
                 timeout: this.timeout
             });
 
-            instance.defaults.headers.common['Authorization'] = opts.authorization;
+            instance.defaults.headers.common['Authorization'] = opts.accessToken;
 
             if ( !this.useCaching || opts.skipCache) {
                 return this._getFulfillmentLocationFromService(instance, locationId, opts)
@@ -93,7 +93,7 @@ class FulfillmentLocationClient {
                     });
             }
 
-            const cacheKey = 'fulfillmentLocation_' + locationId + '_' + opts.authorization;
+            const cacheKey = 'fulfillmentLocation_' + locationId + '_' + opts.accessToken;
             flCache.get(cacheKey, (err, fulfillmentLocation) => {
 
                 if ( err ) {
@@ -123,13 +123,13 @@ class FulfillmentLocationClient {
 
         return new Promise((resolve, reject) => {
             const opts = options || {};
-            handleAuthorization(opts.authorization, reject);
+            handleAuthorization(opts.accessToken, reject);
             const instance = axios.create({
                 baseURL: this.url,
                 timeout: this.timeout
             });
     
-            instance.defaults.headers.common['Authorization'] = opts.authorization;
+            instance.defaults.headers.common['Authorization'] = opts.accessToken;
     
             if ( !this.useCaching || opts.skipCache) {
                 return this._getFulfillmentLocationsFromService(instance, opts)
@@ -141,7 +141,7 @@ class FulfillmentLocationClient {
                     });
             }
 
-            const cacheKey = 'fulfillmentLocations_' + opts.authorization;
+            const cacheKey = 'fulfillmentLocations_' + opts.accessToken;
             flCache.get(cacheKey, (err, fulfillmentLocations) => {
 
                 if ( err ) {

--- a/tests/getFulfillmentLocationTests.js
+++ b/tests/getFulfillmentLocationTests.js
@@ -38,7 +38,26 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service :: skipCache set :: returns 200 and the fresh location requested (using alphanum id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io', {reqheaders: {
+            'Cache-Control': 'no-cache',
+            'X-Cache-Id': (value) => value!= null
+        }})
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(200, sampleLocation());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -54,7 +73,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("a7uqagcx0nz", 'Bearer X')
+        return client.getLocation("a7uqagcx0nz", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -71,7 +90,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("189", 'Bearer X')
+        return client.getLocation("189", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -87,7 +106,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", 'Bearer X')
+        return client.getLocation("180", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -104,7 +123,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", 'Bearer X')
+        return client.getLocation("180", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -120,7 +139,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", 'Bearer X')
+        return client.getLocation("180", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -148,7 +167,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", "invalid-format")
+        return client.getLocation("180", {authorization: 'invalid-format'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -174,7 +193,30 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocation());
+            })
+            .catch(error => {
+                expect(error).to.not.exist;
+            });
+    });
+
+    it('FL service :: skipCache set :: rreturns 200 and the fresh location requested (using alphanum id)', function () {
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io', {reqheaders: {
+            'Cache-Control': 'no-cache',
+            'X-Cache-Id': (value) => value!= null
+        }})
+            .get("/v1/fulfillmentlocations/bqcjg7qbvep")
+            .reply(200, sampleLocation());
+
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -193,7 +235,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("a7uqagcx0nz", 'Bearer X')
+        return client.getLocation("a7uqagcx0nz", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -213,7 +255,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("189", 'Bearer X')
+        return client.getLocation("189", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -232,7 +274,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("180", 'Bearer X')
+        return client.getLocation("180", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -253,7 +295,7 @@ describe('getLocation :: with cache ::', function () {
         });
 
         return client
-            .getLocation("bqcjg7qbvep", 'Bearer X')
+            .getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
             .then(_data => {
                 // FL service is now returning a 404; client should use data in cache
                 nock('https://fulfillmentlocation.trdlnk.cimpress.io')
@@ -261,7 +303,7 @@ describe('getLocation :: with cache ::', function () {
                     .reply(500, "Unable to load information for 'bqcjg7qbvep'");
 
                 client
-                    .getLocation("bqcjg7qbvep", 'Bearer X')
+                    .getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
                     .then(data => {
                         expect(data).to.deep.equal(sampleLocation());
                     })
@@ -283,7 +325,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("bqcjg7qbvep", 'Bearer X')
+        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })

--- a/tests/getFulfillmentLocationTests.js
+++ b/tests/getFulfillmentLocationTests.js
@@ -38,7 +38,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+        return client.getLocation("bqcjg7qbvep", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -57,7 +57,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X', skipCache: true})
+        return client.getLocation("bqcjg7qbvep", {accessToken: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -73,7 +73,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("a7uqagcx0nz", {authorization: 'Bearer X'})
+        return client.getLocation("a7uqagcx0nz", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -90,7 +90,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("189", {authorization: 'Bearer X'})
+        return client.getLocation("189", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -106,7 +106,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", {authorization: 'Bearer X'})
+        return client.getLocation("180", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -123,7 +123,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", {authorization: 'Bearer X'})
+        return client.getLocation("180", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -139,7 +139,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", {authorization: 'Bearer X'})
+        return client.getLocation("180", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -167,7 +167,7 @@ describe('getLocation :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocation("180", {authorization: 'invalid-format'})
+        return client.getLocation("180", {accessToken: 'invalid-format'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -193,7 +193,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+        return client.getLocation("bqcjg7qbvep", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -216,7 +216,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X', skipCache: true})
+        return client.getLocation("bqcjg7qbvep", {accessToken: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -235,7 +235,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("a7uqagcx0nz", {authorization: 'Bearer X'})
+        return client.getLocation("a7uqagcx0nz", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -255,7 +255,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("189", {authorization: 'Bearer X'})
+        return client.getLocation("189", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocation());
             })
@@ -274,7 +274,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("180", {authorization: 'Bearer X'})
+        return client.getLocation("180", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -295,7 +295,7 @@ describe('getLocation :: with cache ::', function () {
         });
 
         return client
-            .getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+            .getLocation("bqcjg7qbvep", {accessToken: 'Bearer X'})
             .then(_data => {
                 // FL service is now returning a 404; client should use data in cache
                 nock('https://fulfillmentlocation.trdlnk.cimpress.io')
@@ -303,7 +303,7 @@ describe('getLocation :: with cache ::', function () {
                     .reply(500, "Unable to load information for 'bqcjg7qbvep'");
 
                 client
-                    .getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+                    .getLocation("bqcjg7qbvep", {accessToken: 'Bearer X'})
                     .then(data => {
                         expect(data).to.deep.equal(sampleLocation());
                     })
@@ -325,7 +325,7 @@ describe('getLocation :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocation("bqcjg7qbvep", {authorization: 'Bearer X'})
+        return client.getLocation("bqcjg7qbvep", {accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })

--- a/tests/getFulfillmentLocationsTests.js
+++ b/tests/getFulfillmentLocationsTests.js
@@ -47,7 +47,27 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization:'Bearer X'})
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocations());
+            });
+    });
+
+    it('FL returns 200 :: skipCache set :: returns fresh list of fulfillment locations correctly', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io', {reqheaders: {
+                'Cache-Control': 'no-cache',
+                'X-Cache-Id': (value) => value!= null
+            }})
+            .get("/v1/fulfillmentlocations")
+            .query({showArchived: false})
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+
+        return client.getLocations({authorization: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -63,7 +83,26 @@ describe('getLocations :: without cache ::', function () {
             .reply(200, sampleLocations());
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
-        return client.getLocations('Bearer X', true)
+        return client.getLocations({authorization: 'Bearer X', showArchived: true})
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocations());
+            });
+    });
+
+    it('FL returns 200 :: skipCache set :: returns list of fresh fulfillment locations correctly including archived fulfillers', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io', {reqheaders: {
+            'Cache-Control': 'no-cache',
+            'X-Cache-Id': (value) => value!= null
+        }})
+            .get("/v1/fulfillmentlocations")
+            .query({showArchived: true})
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({log: defaultLogger()});
+        return client.getLocations({authorization: 'Bearer X', showArchived: true, skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -80,7 +119,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -98,7 +137,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -115,7 +154,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -132,7 +171,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -160,7 +199,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations('invalid-format')
+        return client.getLocations({authorization: 'invalid-format'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -186,7 +225,30 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
+            .then(data => {
+                expect(data).to.deep.equal(sampleLocations());
+            });
+    });
+        
+    it('FL returns 200 :: skipCache set :: returns list of fresh fulfillment locations correctly', function () {
+        nock.cleanAll();
+
+        nock('https://fulfillmentlocation.trdlnk.cimpress.io', {reqheaders: {
+            'Cache-Control': 'no-cache',
+            'X-Cache-Id': (value) => value!= null
+        }})
+            .get("/v1/fulfillmentlocations")
+            .query({showArchived: false})
+            .times(1)
+            .reply(200, sampleLocations());
+
+        let client = new FulfillmentLocationClient({
+            log: defaultLogger(),
+            cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
+        });
+
+        return client.getLocations({authorization: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -206,14 +268,14 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(_data => {
                 nock('https://fulfillmentlocation.trdlnk.cimpress.io')
                     .get("/v1/fulfillmentlocations")
                     .times(1)
                     .reply(500, 'Unable to load locations');
 
-                client.getLocations('Bearer X')
+                client.getLocations({authorization: 'Bearer X'})
                     .then(data => {
                         expect(data).to.deep.equal(sampleLocations());
                     })
@@ -237,7 +299,7 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations('Bearer X')
+        return client.getLocations({authorization: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })

--- a/tests/getFulfillmentLocationsTests.js
+++ b/tests/getFulfillmentLocationsTests.js
@@ -47,7 +47,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization:'Bearer X'})
+        return client.getLocations({accessToken:'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -67,7 +67,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'Bearer X', skipCache: true})
+        return client.getLocations({accessToken: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -83,7 +83,7 @@ describe('getLocations :: without cache ::', function () {
             .reply(200, sampleLocations());
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
-        return client.getLocations({authorization: 'Bearer X', showArchived: true})
+        return client.getLocations({accessToken: 'Bearer X', showArchived: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -102,7 +102,7 @@ describe('getLocations :: without cache ::', function () {
             .reply(200, sampleLocations());
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
-        return client.getLocations({authorization: 'Bearer X', showArchived: true, skipCache: true})
+        return client.getLocations({accessToken: 'Bearer X', showArchived: true, skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -119,7 +119,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -137,7 +137,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -154,7 +154,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -171,7 +171,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -199,7 +199,7 @@ describe('getLocations :: without cache ::', function () {
 
         let client = new FulfillmentLocationClient({log: defaultLogger()});
 
-        return client.getLocations({authorization: 'invalid-format'})
+        return client.getLocations({accessToken: 'invalid-format'})
             .then(data => {
                 expect(data).to.not.exist;
             })
@@ -225,7 +225,7 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -248,7 +248,7 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations({authorization: 'Bearer X', skipCache: true})
+        return client.getLocations({accessToken: 'Bearer X', skipCache: true})
             .then(data => {
                 expect(data).to.deep.equal(sampleLocations());
             });
@@ -268,14 +268,14 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(_data => {
                 nock('https://fulfillmentlocation.trdlnk.cimpress.io')
                     .get("/v1/fulfillmentlocations")
                     .times(1)
                     .reply(500, 'Unable to load locations');
 
-                client.getLocations({authorization: 'Bearer X'})
+                client.getLocations({accessToken: 'Bearer X'})
                     .then(data => {
                         expect(data).to.deep.equal(sampleLocations());
                     })
@@ -299,7 +299,7 @@ describe('getLocations :: with cache ::', function () {
             cacheConfig: { stdTTL: 4 * 60 * 60, checkperiod: 5 * 60 }
         });
 
-        return client.getLocations({authorization: 'Bearer X'})
+        return client.getLocations({accessToken: 'Bearer X'})
             .then(data => {
                 expect(data).to.not.exist;
             })


### PR DESCRIPTION
Added the posibility of skiping the cache of CloudFront and the Browser adding the headers `Cache-Control: no-cache` and `X-Cache-Id: Math.random()` if the parameter skipCache is provided with the value `true`, 

The way we were adding parameters to the functions will become unreadable if we keep adding them.

Adding an object it's much more intuitive. See:
```
fl.getLocations('TOKEN',true,true)
```
```
fl.getLocations({
   authorization: "TOKEN",
   skipCache: true,
   showArchived: true
})
```